### PR TITLE
SE-1163 Module Engagement: handle case when no elasticsearch host is configured

### DIFF
--- a/edx/analytics/tasks/util/s3_util.py
+++ b/edx/analytics/tasks/util/s3_util.py
@@ -135,7 +135,7 @@ class ScalableS3Client(S3Client):
         if not aws_secret_access_key:
             aws_secret_access_key = self._get_s3_config('aws_secret_access_key')
         if 'host' not in kwargs:
-            kwargs['host'] = self._get_s3_config('host') or 's3.amazonaws.com'
+            kwargs['host'] = self._get_s3_config('host') or 's3.eu-west-1.amazonaws.com'
 
         super(ScalableS3Client, self).__init__(aws_access_key_id=aws_access_key_id, aws_secret_access_key=aws_secret_access_key, **kwargs)
 


### PR DESCRIPTION
Ports customizations into client's Ironwood branch.

* Runs just `ModuleEngagementRosterPartitionTask` instead of the full `ModuleEngagementRosterIndexTask` if no elasticsearch host is configured.
  This change is an upstream-able version of the [code drift contained in the client's branch](https://github.com/open-craft/edx-analytics-pipeline/commit/1777df225409c375cd8657f06f378e06600927af).
* Hard-codes the S3 host endpoint to `eu-west-1`, because all attempts to customize it using configuration were unsuccessful.  cf [discussion on openedx forum](https://discuss.openedx.org/t/analytics-pipeline-failing-on-non-us-s3-buckets/178).
  This is not upstreamable code drift, but may be addressable via config when [upstream completes conversion to `boto3`](https://github.com/edx/edx-analytics-pipeline/blob/master/edx/analytics/tasks/util/s3_util.py#L125-L127).

**Test instructions**

Can be tested during deployment of client's Ironwood.2 analytics upgrade.  To verify the change is working as expected:

1.  All tasks run successfully when configured to use this branch.
1. `ModuleEngagementRosterPartitionTask` shows in the `ModuleEngagementWorkflowTask` task logs.

**Reviewer**

- [x] @swalladge