### PR TITLE
[FAL-300] Fix bad pip version 21 symlinking

### DIFF
--- a/share/task.yml
+++ b/share/task.yml
@@ -148,9 +148,15 @@
         virtualenv --python={{ virtualenv_python }} {{ virtualenv_extra_args }} {{ working_venv_dir }}
       when: not virtualenv_created.stat.exists
 
-    - name: update pip
-      command: >
-        {{ working_venv_dir }}/bin/pip install -U pip
+    - name: download pip
+      get_url:
+        url: 'https://bootstrap.pypa.io/2.7/get-pip.py'
+        dest: /tmp/get-pip.py
+
+    - name: install pip
+      command: "{{ working_venv_dir }}/bin/python get-pip.py"
+      args:
+        chdir: /tmp
 
     - name: virtualenv initialized on Debian
       shell: >


### PR DESCRIPTION
This pull request is about fixing a bad pip symlink in a virtualenv. Because pip 21 dropped Python 2 support, the virtualenv' pip binary was a symlink to the system pip binary which was using version 21.

This fix, force pip (python 2) binary install inside the virtualenv.

**Jira tickets**

- [FAL-300](https://tasks.opencraft.com/browse/FAL-300)


**Testing instructions**

In the ticket.

**Reviewers**

- @s0b0lev 
