### PR TITLE
[SE-4097] Fix wrong pip symlinking

### DIFF
--- a/share/task.yml
+++ b/share/task.yml
@@ -148,9 +148,15 @@
         virtualenv --python={{ virtualenv_python }} {{ virtualenv_extra_args }} {{ working_venv_dir }}
       when: not virtualenv_created.stat.exists
 
-    - name: update pip
-      command: >
-        {{ working_venv_dir }}/bin/pip install -U pip
+    - name: download pip
+      get_url:
+        url: 'https://bootstrap.pypa.io/2.7/get-pip.py'
+        dest: /tmp/get-pip.py
+
+    - name: install pip
+      command: "{{ working_venv_dir }}/bin/python get-pip.py"
+      args:
+        chdir: /tmp
 
     - name: virtualenv initialized on Debian
       shell: >


### PR DESCRIPTION
"This pull request is about fixing a bad pip symlink in a virtualenv. Because pip 21 dropped Python 2 support, the virtualenv' pip binary was a symlink to the system pip binary which was using version 21.

This fix, force pip (python 2) binary install inside the virtualenv."

\- @toxinu , [original PR](https://github.com/open-craft/edx-analytics-pipeline/pull/13) author.

This is a backport of this fix for the ginko.2 branch.

## Jira tickets

    https://tasks.opencraft.com/browse/SE-4097

## Testing instructions

In Jenkins, start one of the failed Analytics pipelines with this branch, such as 'enrollment-workflow' or 'geolocation-workflow'. Don't do 'answer-distribution-workflow' since that one's processing right now already.

## Reviewers

- [x] @clemente
- [x] @itsjeyd 